### PR TITLE
Add links to recordings

### DIFF
--- a/community/seminars/modeling/modeling_2020.md
+++ b/community/seminars/modeling/modeling_2020.md
@@ -13,9 +13,11 @@ hero_height: is_fullheight
 
 ## 2020
 
+[Recordings](https://github.com/IDEAS-Watersheds/best-practices-seminar#2020)
+
 | Date     |  Presenter                             | Title and Topic Description                    |
 |:---------|:---------------------------------------|:-----------------------------------------------|
-| Jun 17  |Ahmad Jan and Saubhagya Rathore (ORNL)  | Multiscale modeling of stream corridor hydrobiogeochemistry with ATS | 
+| Jun 17  |Ahmad Jan and Saubhagya Rathore (ORNL)  | Multiscale modeling of stream corridor hydrobiogeochemistry with ATS| 
 | Jul 1   |Kewei Chen (PNNL), Tristan Babey (SLAC) | Using a column experiment as an example for benchmarking reactive transport simulators |
 | Jul 15  |Ilhan Ozgen (LBNL)                      | Modeling integrated hydrology using the IDEAS-Watersheds software ecosystem |
 | Jul 29  | Ethan Coon (ORNL)                      | Watershed modeling fundamentals: setup, data inputs, ATS model specifics (mesh generation/workflow) |
@@ -24,7 +26,7 @@ hero_height: is_fullheight
 | Sep 23  | Glenn Hammond, Sergi Molins            | Reactive Transport Fundamentals |
 | Oct 7    | 2020 Virtual Annual Meeting            | |
 | Nov 18   |  Yilin Fang (PNNL), Scott Painter (ORNL) | Multiscale modeling of reactive transport in stream and river corridors (Part I) |
-| Dec 2    | Scott Painter (ORNL)                   | Multiscale modeling of reactive transport in stream and river corridors (Part II) |
+| Dec 2    | Scott Painter (ORNL)                   | Multiscale modeling of reactive transport in stream and river corridors (Part II)  |
 
 
 

--- a/community/seminars/modeling/modeling_2021.md
+++ b/community/seminars/modeling/modeling_2021.md
@@ -13,6 +13,8 @@ hero_height: is_fullheight
 
 ## 2021
 
+[Recordings](https://github.com/IDEAS-Watersheds/best-practices-seminar#2021)
+
 | Date        |  Presenter                             | Title and Topic Description                    |
 |:------------|:---------------------------------------|:-----------------------------------------------|
 | Jan 27      | Jesus Gomez-Velez, Vanderbilt University | Status on Network with Exchange and Subsurface Storage (NEXSS) model |

--- a/community/seminars/modeling/modeling_2022.md
+++ b/community/seminars/modeling/modeling_2022.md
@@ -13,6 +13,8 @@ hero_height: is_fullheight
 
 ## 2022
 
+[Recordings](https://github.com/IDEAS-Watersheds/best-practices-seminar#2022)
+
 | Date        |  Presenter                             | Title and Topic Description                    |
 |:------------|:---------------------------------------|:-----------------------------------------------|
 | Jun 13      | Scott Painter, ORNL                    | Projections of permafrost thaw and subsidence using a multiscale model from IDEAS-Classic |

--- a/community/seminars/modeling/modeling_2023.md
+++ b/community/seminars/modeling/modeling_2023.md
@@ -15,3 +15,7 @@ hero_height: is_fullheight
 | Date        |  Presenter                             | Title and Topic Description                    |
 |:------------|:---------------------------------------|:-----------------------------------------------|
 | May 2      | Zhi Li, PNNL                     | Watershed hydrologic and biogeochemical responses to wildfires in the Pacific Northwest |
+| May 9     | Sergi Molins, LBNL                        | Discussion on setting up reactive transport simulations using external engines via Alquimia, Part I |
+| May 30     | Sergi Molins, LBNL                        | Discussion on setting up reactive transport simulations using external engines via Alquimia, Part II |
+| Jun 6     | Roser Matamala, Argonne                        | Ideas for a terrestrial wetland function and resilience Scientific Focus Area|
+| Aug 15      | Phong Le, ORNL                        | Evaluating a multiscale stream transport model using a long-term watershed-scale tracer test|

--- a/community/seminars/software/software_2019.md
+++ b/community/seminars/software/software_2019.md
@@ -13,6 +13,8 @@ hero_height: is_fullheight
 
 ## 2019
 
+[Recordings](https://github.com/IDEAS-Watersheds/best-practices-seminar#2019)
+
 | Date      |   Presenter                            | Title and Topic Description                    |
 |:----------|:---------------------------------------|:-----------------------------------------------|
 | Sep 9    | Steve Smith                            | Introduction & Kick-Off |

--- a/community/seminars/software/software_2020.md
+++ b/community/seminars/software/software_2020.md
@@ -13,6 +13,9 @@ hero_height: is_fullheight
 
 ## 2020
 
+
+[Recordings](https://github.com/IDEAS-Watersheds/best-practices-seminar#2020)
+
 | Date      |   Presenter                            | Title and Topic Description                    |
 |:----------|:---------------------------------------|:-----------------------------------------------|
 | Jan 15    | Steve Smith                            | Debugging Best Practices |

--- a/community/seminars/software/software_2021.md
+++ b/community/seminars/software/software_2021.md
@@ -13,6 +13,8 @@ hero_height: is_fullheight
 
 ## 2021
 
+[Recordings](https://github.com/IDEAS-Watersheds/best-practices-seminar#2021)
+
 | Date      |   Presenter                            | Title and Topic Description                    |
 |:----------|:---------------------------------------|:-----------------------------------------------|
 | Feb 5     | Ian Lee, LLNL                          | Open Source Software and discussion |

--- a/community/seminars/software/software_2022.md
+++ b/community/seminars/software/software_2022.md
@@ -13,6 +13,9 @@ hero_height: is_fullheight
 
 ## 2022
 
+[Recordings](https://github.com/IDEAS-Watersheds/best-practices-seminar#2022)
+
+
 | Date      |   Presenter                            | Title and Topic Description                    |
 |:----------|:---------------------------------------|:-----------------------------------------------|
 | Jun 20    | Steve Smith, LLNL; Giacomo Capodaglio, LANL  | Updates on Spack for ATS and ParFlow/Ecoslim – open discussion on next steps |

--- a/community/seminars/software/software_2023.md
+++ b/community/seminars/software/software_2023.md
@@ -12,7 +12,8 @@ hero_height: is_fullheight
 
 ## 2023
 
-| Date      |   Presenter                            | Title and Topic Description                    |
-|:----------|:---------------------------------------|:-----------------------------------------------|
-| May 9    | Sergi Molins, LBNL  | Discussion on setting up reactive transport simulations using external engines via Alquimia - Part I |
-| May 30    | Sergi Molins, LBNL  | Discussion on setting up reactive transport simulations using external engines via Alquimia - Part II |
+| Date          |   Presenter                            | Title and Topic Description                    |
+|:--------------|:---------------------------------------|:-----------------------------------------------|
+| Aug 2         | Steven Smith, LLNL  | Code reviews |
+| Aug 22        | David Moulton & Rich Fiorella, LANL  | Hands-on docker tips for working with containers in our software ecosystem |
+| Sep 12        | Saubhagya Rathore, ORNL  | A stream-aligned mixed/arbitrary polyhedral meshing strategy for integrated surface/subsurface hydrological models |


### PR DESCRIPTION
Also updates content for 2023
Addresses: https://github.com/IDEAS-Watersheds/ideas-watersheds.github.io/issues/15

Note: I only point to the public table with recording links on git. Individual recordings are not stored on a publically accessible drive. We may want to change that.