### PR TITLE
bug fix: permalink needs to be consistent 

### DIFF
--- a/_data/home_callouts.yml
+++ b/_data/home_callouts.yml
@@ -18,6 +18,6 @@ items:
       IDEAS-Watersheds discussions
     icon: fa-comments
     call_to_action_name: Learn More
-    call_to_action_link: /resources/seminars/
+    call_to_action_link: /resources/seminars
 
 #https://aksakalli.github.io/jekyll-doc-theme/docs/font-awesome/


### PR DESCRIPTION
hopes to address issue #27, broken link bug with resources/seminars.md introduced by David with 2e25d6c.